### PR TITLE
DD-1677, DD-1678 and --fail-fast option

### DIFF
--- a/src/main/java/nl/knaw/dans/avexports/EasyConvertAvExports.java
+++ b/src/main/java/nl/knaw/dans/avexports/EasyConvertAvExports.java
@@ -53,6 +53,10 @@ public class EasyConvertAvExports extends AbstractCommandLineAppJava8<EasyConver
             description = "Move the input to the staging directory instead of copying it")
     private boolean move;
 
+    @Option(names = { "-f", "--fail-fast" },
+            description = "Fail run on first error")
+    private boolean failFast;
+
     private Path stagingDir;
 
     private final AvDatasetConverter.AvDatasetConverterBuilder builder = AvDatasetConverter.builder();
@@ -91,6 +95,7 @@ public class EasyConvertAvExports extends AbstractCommandLineAppJava8<EasyConver
             builder
                 .fedoraExports(fedoraExports)
                 .outputDir(outputDir)
+                .failFast(failFast)
                 .build()
                 .convert();
             return 0;

--- a/src/main/java/nl/knaw/dans/avexports/core/Sources.java
+++ b/src/main/java/nl/knaw/dans/avexports/core/Sources.java
@@ -23,7 +23,6 @@ import org.apache.commons.csv.CSVRecord;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -57,7 +56,7 @@ public class Sources {
         return datasetIdToSpringfieldFileIds.get(easyDatasetId);
     }
 
-    public boolean hasSpringfieldFiles(String easyDatasetId) {
+    public boolean hasSpringfieldFilesFor(String easyDatasetId) {
         return datasetIdToSpringfieldFileIds.containsKey(easyDatasetId);
     }
 }


### PR DESCRIPTION
Fixes DD-1677, DD-1678

# Description of changes

* Large Copilot assisted refactoring to make the code more readable.
* Made sure that empty pseudo-file are also deleted from version 2 if there are not springfield files
* Logging errors before exiting because of an uncaught exception
* `--fail-fast` option 


# Notify

@DANS-KNAW/core-systems
